### PR TITLE
feat(ci): add actionlint workflow validation and git hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
       - name: Run tests
         run: dotnet test ${{ env.SOLUTION }} --no-build --verbosity normal --configuration ${{ env.CONFIGURATION }}
 
+  validate-workflows:
+    name: Validate Workflows
+    uses: kjldev/.github/.github/workflows/validate-workflows.yml@main
+
   changeset-check:
     name: Changeset Check
     uses: kjldev/.github/.github/workflows/changeset-check.yml@main
@@ -92,6 +96,7 @@ jobs:
       - format-check
       - build-and-test
       - build-and-test-samples
+      - validate-workflows
       - changeset-check
 
     steps:
@@ -100,6 +105,7 @@ jobs:
           FORMAT_CHECK_RESULT: ${{ needs['format-check'].result }}
           BUILD_AND_TEST_RESULT: ${{ needs['build-and-test'].result }}
           BUILD_AND_TEST_SAMPLES_RESULT: ${{ needs['build-and-test-samples'].result }}
+          VALIDATE_WORKFLOWS_RESULT: ${{ needs['validate-workflows'].result }}
           CHANGESET_CHECK_RESULT: ${{ needs['changeset-check'].result }}
         shell: bash
         run: |
@@ -109,6 +115,7 @@ jobs:
             ["Format Check"]="${FORMAT_CHECK_RESULT}"
             ["Build and Test"]="${BUILD_AND_TEST_RESULT}"
             ["Build and Test Samples"]="${BUILD_AND_TEST_SAMPLES_RESULT}"
+            ["Validate Workflows"]="${VALIDATE_WORKFLOWS_RESULT}"
             ["Changeset Check"]="${CHANGESET_CHECK_RESULT}"
           )
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,11 +1,11 @@
 #!/bin/sh
 # Validate GitHub Actions workflow files before commit.
-# Install actionlint: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+# Install actionlint: scoop install actionlint  (or: go install github.com/rhysd/actionlint/cmd/actionlint@latest)
 
 if command -v actionlint >/dev/null 2>&1; then
   echo "Running actionlint..."
   actionlint
 else
   echo "⚠️  actionlint not found — workflow validation skipped."
-  echo "   Install: go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+  echo "   Install: scoop install actionlint  (or: go install github.com/rhysd/actionlint/cmd/actionlint@latest)"
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Validate GitHub Actions workflow files before commit.
+# Install actionlint: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+if command -v actionlint >/dev/null 2>&1; then
+  echo "Running actionlint..."
+  actionlint
+else
+  echo "⚠️  actionlint not found — workflow validation skipped."
+  echo "   Install: go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,11 +1,11 @@
 #!/bin/sh
 # Validate GitHub Actions workflow files before push.
-# Install actionlint: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+# Install actionlint: scoop install actionlint  (or: go install github.com/rhysd/actionlint/cmd/actionlint@latest)
 
 if command -v actionlint >/dev/null 2>&1; then
   echo "Running actionlint..."
   actionlint
 else
   echo "⚠️  actionlint not found — workflow validation skipped."
-  echo "   Install: go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+  echo "   Install: scoop install actionlint  (or: go install github.com/rhysd/actionlint/cmd/actionlint@latest)"
 fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Validate GitHub Actions workflow files before push.
+# Install actionlint: go install github.com/rhysd/actionlint/cmd/actionlint@latest
+
+if command -v actionlint >/dev/null 2>&1; then
+  echo "Running actionlint..."
+  actionlint
+else
+  echo "⚠️  actionlint not found — workflow validation skipped."
+  echo "   Install: go install github.com/rhysd/actionlint/cmd/actionlint@latest"
+fi

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
         "@changesets/cli": "^2.27.12",
+        "husky": "^9.1.7",
       },
     },
   },
@@ -112,6 +113,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"readme": "README.md",
 	"scripts": {
 		"changeset": "changeset",
-		"version-packages": "changeset version && bun .build/update-version.ts"
+		"version-packages": "changeset version && bun .build/update-version.ts",
+		"prepare": "husky"
 	},
 	"repository": {
 		"type": "git",
@@ -19,6 +20,7 @@
 	"homepage": "https://github.com/kjldev/purview-telemetry-sourcegenerator#readme",
 	"devDependencies": {
 		"@changesets/changelog-github": "^0.5.0",
-		"@changesets/cli": "^2.27.12"
+		"@changesets/cli": "^2.27.12",
+		"husky": "^9.1.7"
 	}
 }


### PR DESCRIPTION
Adds actionlint-based workflow validation at every layer.

## What
- **CI**: new \alidate-workflows\ job calls the reusable \kjldev/.github/.github/workflows/validate-workflows.yml\ workflow — runs actionlint on every PR, wired into \ci-gate\
- **Pre-commit hook** (\.husky/pre-commit\): runs actionlint before every commit
- **Pre-push hook** (\.husky/pre-push\): second check at push time
- Both hooks skip gracefully with an install hint if actionlint isn't found
- Install: \scoop install actionlint\

## Why
Catches invalid action versions (e.g. \checkout@v6\), bad expressions, and YAML errors locally before they reach GitHub.