### PR TITLE
chore: remove husky

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Set up .NET
         if: ${{ steps.release-check.outputs.should_release == 'true' }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./global.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./global.json
 
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./src/global.json
 
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./samples/SampleApp/global.json
 

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-	"name": "purview-telemetry-sourcegenerator",
-	"version": "4.2.0",
-	"description": "Generates [`ActivitySource`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource), [`ILogger`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger), and [`Metrics`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics) based on interface methods.",
-	"readme": "README.md",
-	"scripts": {
-		"changeset": "changeset",
-		"version-packages": "changeset version && bun .build/update-version.ts"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/kjldev/purview-telemetry-sourcegenerator.git"
-	},
-	"author": "Kieron Lanning (https://github.com/kieronlanning/)",
-	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/kjldev/purview-telemetry-sourcegenerator/issues"
-	},
-	"homepage": "https://github.com/kjldev/purview-telemetry-sourcegenerator#readme",
-	"devDependencies": {
-		"@changesets/changelog-github": "^0.5.0",
-		"@changesets/cli": "^2.27.12"
-	}
+  "name": "purview-telemetry-sourcegenerator",
+  "version": "4.2.0",
+  "description": "Generates [`ActivitySource`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource), [`ILogger`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger), and [`Metrics`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics) based on interface methods.",
+  "readme": "README.md",
+  "scripts": {
+    "changeset": "changeset",
+    "version-packages": "changeset version && bun .build/update-version.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kjldev/purview-telemetry-sourcegenerator.git"
+  },
+  "author": "Kieron Lanning (https://github.com/kieronlanning/)",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/kjldev/purview-telemetry-sourcegenerator/issues"
+  },
+  "homepage": "https://github.com/kjldev/purview-telemetry-sourcegenerator#readme",
+  "devDependencies": {
+    "@changesets/changelog-github": "^0.5.0",
+    "@changesets/cli": "^2.27.12"
+  }
 }


### PR DESCRIPTION
Removes husky - no git hooks needed. Actionlint runs in CI via the \alidate-workflows\ job in \kjldev/.github\.