### PR TITLE
fix(release): skip wiki push in CI, add post-release wiki update to CD

### DIFF
--- a/.build/update-version.ts
+++ b/.build/update-version.ts
@@ -147,6 +147,14 @@ function pushWiki() {
 }
 
 // --- Main ---
-pullWiki();
+// When running in CI (changeset version PR creation), skip the wiki push.
+// The wiki is updated post-release in the CD pipeline instead.
+const isCI = !!process.env.GITHUB_ACTIONS;
+
+if (!isCI) {
+	pullWiki();
+}
 updateFilesVersion();
-pushWiki();
+if (!isCI) {
+	pushWiki();
+}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -163,3 +163,25 @@ jobs:
         if: ${{ steps.release-check.outputs.should_release != 'true' }}
         run: echo "Release ${{ steps.version.outputs.tag }} already exists — skipping."
 
+      - name: Set up Bun
+        if: ${{ steps.release-check.outputs.should_release == 'true' }}
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        if: ${{ steps.release-check.outputs.should_release == 'true' }}
+        run: bun install
+
+      - name: Update wiki
+        if: ${{ steps.release-check.outputs.should_release == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
+          bun .build/update-version.ts
+

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -63,7 +63,7 @@ jobs:
 
       - name: Set up .NET
         if: ${{ steps.release-check.outputs.should_release == 'true' }}
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./global.json
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./global.json
 
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./src/global.json
 
@@ -64,10 +64,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: ./samples/SampleApp/global.json
 

--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
-	"name": "purview-telemetry-sourcegenerator",
-	"version": "4.2.0",
-	"description": "Generates [`ActivitySource`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource), [`ILogger`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger), and [`Metrics`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics) based on interface methods.",
-	"readme": "README.md",
-	"scripts": {
-		"changeset": "changeset",
-		"version-packages": "changeset version && bun .build/update-version.ts"
-	},
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/kjldev/purview-telemetry-sourcegenerator.git"
-	},
-	"author": "Kieron Lanning (https://github.com/kieronlanning/)",
-	"license": "ISC",
-	"bugs": {
-		"url": "https://github.com/kjldev/purview-telemetry-sourcegenerator/issues"
-	},
-	"homepage": "https://github.com/kjldev/purview-telemetry-sourcegenerator#readme",
-	"devDependencies": {
-		"@changesets/changelog-github": "^0.5.0",
-		"@changesets/cli": "^2.27.12"
-	}
+  "name": "purview-telemetry-sourcegenerator",
+  "version": "4.2.0",
+  "description": "Generates [`ActivitySource`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activitysource), [`ILogger`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger), and [`Metrics`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.metrics) based on interface methods.",
+  "readme": "README.md",
+  "scripts": {
+    "changeset": "changeset",
+    "version-packages": "changeset version && bun .build/update-version.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kjldev/purview-telemetry-sourcegenerator.git"
+  },
+  "author": "Kieron Lanning (https://github.com/kieronlanning/)",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/kjldev/purview-telemetry-sourcegenerator/issues"
+  },
+  "homepage": "https://github.com/kjldev/purview-telemetry-sourcegenerator#readme",
+  "devDependencies": {
+    "@changesets/changelog-github": "^0.5.0",
+    "@changesets/cli": "^2.27.12"
+  }
 }


### PR DESCRIPTION
Fixes version-packages script failing in CI (wiki push blocked by missing credentials). Moves wiki update to CD post-release step.